### PR TITLE
Fix build warnings and errors on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ name = "ecflash"
 
 [dev-dependencies]
 libc = "0.2"
-redox_hwio = "0.1.3"
+redox_hwio = "0.1.4"
 serialport = "3.3"

--- a/examples/flash.rs
+++ b/examples/flash.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_range_loop)]
+
 extern crate ecflash;
 
 use ecflash::{EcFlash, Flasher};
@@ -40,13 +42,13 @@ fn main() {
             let mut success = false;
 
             if let Ok(_original) = flasher.read(|x| eprint!("\rRead: {} KB", x / 1024)) {
-                eprintln!("");
+                eprintln!();
 
                 if flasher.erase(|x| eprint!("\rErase: {} KB", x / 1024)).is_ok() {
-                    eprintln!("");
+                    eprintln!();
 
                     if let Ok(erased) = flasher.read(|x| eprint!("\rRead: {} KB", x / 1024)) {
-                        eprintln!("");
+                        eprintln!();
 
                         //TODO: retry erase on fail
                         for i in 0..erased.len() {
@@ -60,10 +62,10 @@ fn main() {
                         }
 
                         if flasher.write(&data, |x| eprint!("\rWrite {} KB", x / 1024)).is_ok() {
-                            eprintln!("");
+                            eprintln!();
 
                             if let Ok(written) = flasher.read(|x| eprint!("\rRead: {} KB", x / 1024)) {
-                                eprintln!("");
+                                eprintln!();
 
                                 success = true;
                                 for i in 0..written.len() {

--- a/examples/isp.rs
+++ b/examples/isp.rs
@@ -1,3 +1,7 @@
+#![allow(dead_code)]
+#![allow(clippy::missing_safety_doc)]
+#![allow(clippy::needless_range_loop)]
+
 use hwio::{Io, Pio};
 use serialport::{Error, ErrorKind, Result, SerialPortSettings, posix::TTYPort};
 use std::any::Any;
@@ -695,7 +699,7 @@ fn isp_inner<T: Any + Smfi>(port: &mut T, firmware: &[u8]) -> Result<()> {
             spi.write_disable()?;
         } else {
             eprintln!("SPI AAI word program");
-            spi.write_at(0, &firmware)?;
+            spi.write_at(0, firmware)?;
         }
 
 

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -21,13 +21,13 @@ fn main() {
 
         if flasher.start() == Ok(51) {
             if let Ok(data) = flasher.read(|x| { eprint!("\r{} KB", x / 1024) }) {
-                eprintln!("");
+                eprintln!();
                 let _ = fs::write("read.rom", data);
             } else {
                 eprintln!("Failed to read data");
             }
 
-            flasher.stop();
+            let _ = flasher.stop();
         } else {
             eprintln!("Failed to start flasher");
         }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_safety_doc)]
+
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -10,8 +12,8 @@ impl EcFile {
         let mut string = String::new();
 
         let mut i = 0;
-        let mut bytes = self.0.iter();
-        while let Some(&byte) = bytes.next() {
+        let bytes = self.0.iter();
+        for &byte in bytes {
             loop {
                 if i < key.len() {
                     if byte == key[i] {
@@ -50,7 +52,7 @@ impl Ec for EcFile {
 
     fn version(&mut self) -> String {
         let mut version = unsafe { self.get_str(b"VER:") };
-        while version.chars().next() == Some(' ') {
+        while version.starts_with(' ') {
             version.remove(0);
         }
         version

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -1,3 +1,7 @@
+#![allow(clippy::missing_safety_doc)]
+// TODO: Use real errors
+#![allow(clippy::result_unit_err)]
+
 use alloc::string::String;
 
 use super::Ec;
@@ -145,9 +149,9 @@ impl EcFlash {
         };
 
         let ec = Self {
-            primary: primary,
-            data_port: data_port,
-            cmd_port: cmd_port,
+            primary,
+            data_port,
+            cmd_port,
         };
 
         Ok(ec)
@@ -168,13 +172,13 @@ impl Ec for EcFlash {
     fn project(&mut self) -> String {
         let _ = unsafe { self.flush() };
 
-        unsafe { self.get_str(0x92) }.unwrap_or(String::new())
+        unsafe { self.get_str(0x92) }.unwrap_or_default()
     }
 
     fn version(&mut self) -> String {
         let _ = unsafe { self.flush() };
 
-        let mut version = unsafe { self.get_str(0x93) }.unwrap_or(String::new());
+        let mut version = unsafe { self.get_str(0x93) }.unwrap_or_default();
         version.insert_str(0, "1.");
         version
     }

--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -1,3 +1,7 @@
+#![allow(clippy::missing_safety_doc)]
+// TODO: Use real errors
+#![allow(clippy::result_unit_err)]
+
 use alloc::vec::Vec;
 
 use super::{Ec, EcFlash};

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,11 +1,11 @@
 #[inline(always)]
 pub unsafe fn inb(port: u16) -> u8 {
     let value: u8;
-    llvm_asm!("in $0, $1" : "={al}"(value) : "{dx}"(port) : "memory" : "intel", "volatile");
+    asm!("in al, dx", out("al") value, in("dx") port, options(nostack));
     value
 }
 
 #[inline(always)]
 pub unsafe fn outb(port: u16, value: u8) {
-    llvm_asm!("out $1, $0" : : "{al}"(value), "{dx}"(port) : "memory" : "intel", "volatile");
+    asm!("out dx, al", in("al") value, in("dx") port, options(nostack));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(llvm_asm)]
+#![feature(asm)]
 
 #[macro_use]
 extern crate alloc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
         }
     }
 
-    let mut ecs: Vec<(String, Box<Ec>)> = Vec::new();
+    let mut ecs: Vec<(String, Box<dyn Ec>)> = Vec::new();
 
     for arg in env::args().skip(1) {
         match arg.as_str() {


### PR DESCRIPTION
Update redox_hwio to fix building dependencies on nightly.

Fix warnings:

- deprecated
- bare_trait_objects
- unused_must_use
- clippy::chars_next_cmp
- clippy::while_let_on_iterator
- clippy::redundant_field_names
- clippy::needless_borrow
- clippy::println_empty_string

Silence warnings:

- dead_code
- clippy::missing_safety_doc
- clippy::needless_range_loop
- clippy::result_unit_err
