### PR TITLE
Use asm from core::arch

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -1,3 +1,5 @@
+use core::arch::asm;
+
 #[inline(always)]
 pub unsafe fn inb(port: u16) -> u8 {
     let value: u8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(asm)]
 
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
asm was stabilized in Rust 1.59.0. It is now in `core::arch` and not in the prelude.

Fixes compiling using the 2022-03-18 toolchain.