### PR TITLE
Remove unused `redox_hwio` crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,4 @@ name = "ecflash"
 
 [dev-dependencies]
 libc = "0.2.121"
-redox_hwio = "0.1.5"
 serialport = "4.1.0"


### PR DESCRIPTION
Signed-off-by: Garret Kelly <gkelly@gkel.ly>